### PR TITLE
V1

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,9 +102,6 @@ You can ask the batch for other bits of information:
     # => "230923asdlkj230923"
     batch.job_ids
     # => ["b67af7a0-3ed2-4661-a2d5-ff6b6a254886", "6c0216b9-ea0c-4ee9-a3b2-501faa919a66"]
-    batch.expire_in
-    # => 259200
-
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -103,6 +103,12 @@ You can ask the batch for other bits of information:
     batch.job_ids
     # => ["b67af7a0-3ed2-4661-a2d5-ff6b6a254886", "6c0216b9-ea0c-4ee9-a3b2-501faa919a66"]
 
+You can also search for batches:
+    ActiveJobStatus::JobBatch.find(batch_id: my_key)
+
+This method will return nil no associated job ids can be found, otherwise it will 
+return an ActiveJobStatus::JobBatch object.
+
 ## Contributing
 
 1. Fork it ( https://github.com/[my-github-username]/active_job_status/fork )

--- a/lib/active_job_status/job_batch.rb
+++ b/lib/active_job_status/job_batch.rb
@@ -54,13 +54,6 @@ module ActiveJobStatus
                                     job_ids: job_ids,
                                     expire_in: @expire_in,
                                     store_data: false)
-=begin
-      if ActiveJobStatus.store.class.to_s == "ActiveSupport::Cache::RedisStore"
-        ActiveJobStatus.store.smembers(batch_id)
-      else
-        ActiveJobStatus.store.fetch(batch_id).to_a
-      end
-=end
     end
 
     private

--- a/lib/active_job_status/job_batch.rb
+++ b/lib/active_job_status/job_batch.rb
@@ -12,7 +12,7 @@ module ActiveJobStatus
       self.store_data(expire_in: expire_in) if store_data
     end
 
-    def store_data(expire_in)
+    def store_data(expire_in:)
       ActiveJobStatus.store.delete(@batch_id) # delete any old batches
       if ActiveJobStatus.store.class.to_s == "ActiveSupport::Cache::RedisStore"
         ActiveJobStatus.store.sadd(@batch_id, @job_ids)

--- a/lib/active_job_status/job_batch.rb
+++ b/lib/active_job_status/job_batch.rb
@@ -48,9 +48,11 @@ module ActiveJobStatus
         job_ids = ActiveJobStatus.store.fetch(batch_id).to_a
       end
 
-      ActiveJobStatus::JobBatch.new(batch_id: batch_id,
-                                    job_ids: job_ids,
-                                    store_data: false)
+      if job_ids.any?
+        ActiveJobStatus::JobBatch.new(batch_id: batch_id,
+                                      job_ids: job_ids,
+                                      store_data: false)
+      end
     end
 
     private

--- a/lib/active_job_status/job_batch.rb
+++ b/lib/active_job_status/job_batch.rb
@@ -52,7 +52,7 @@ module ActiveJobStatus
 
       ActiveJobStatus::JobBatch.new(batch_id: batch_id,
                                     job_ids: job_ids,
-                                    expire_in: 259200,
+                                    expire_in: @expire_in,
                                     store_data: false)
 =begin
       if ActiveJobStatus.store.class.to_s == "ActiveSupport::Cache::RedisStore"

--- a/lib/active_job_status/trackable_job.rb
+++ b/lib/active_job_status/trackable_job.rb
@@ -1,11 +1,11 @@
 require "active_job"
-class ActiveJobStatus::TrackableJob < ActiveJob::Base
+module ActiveJobStatus
+  class TrackableJob < ActiveJob::Base
 
-  before_enqueue { ActiveJobStatus::JobTracker.enqueue(job_id: @job_id) }
+    before_enqueue { ActiveJobStatus::JobTracker.enqueue(job_id: @job_id) }
 
-  before_perform { ActiveJobStatus::JobTracker.update(job_id: @job_id, status: :working) }
+    before_perform { ActiveJobStatus::JobTracker.update(job_id: @job_id, status: :working) }
 
-  after_perform { ActiveJobStatus::JobTracker.remove(job_id: @job_id) }
+    after_perform { ActiveJobStatus::JobTracker.remove(job_id: @job_id) }
+  end
 end
-
-

--- a/spec/job_batch_spec.rb
+++ b/spec/job_batch_spec.rb
@@ -18,9 +18,6 @@ describe ActiveJobStatus::JobBatch do
   let!(:batch) { ActiveJobStatus::JobBatch.new(batch_id: batch_id,
                                               job_ids: first_jobs) }
 
-  let(:no_jobs_batch) { ActiveJobStatus::JobBatch.new(batch_id: "foo",
-                                                      job_ids: []) }
-
 
   describe "#initialize" do
     it "should create an object" do
@@ -37,12 +34,6 @@ describe ActiveJobStatus::JobBatch do
     describe "when jobs are present" do
       it "should return an array of job ids" do
         expect(batch.job_ids).to match_array(first_jobs)
-      end
-    end
-
-    describe "when no jobs are present" do
-      it "should return an empty array" do
-        expect(no_jobs_batch.job_ids).to eq []
       end
     end
   end

--- a/spec/job_batch_spec.rb
+++ b/spec/job_batch_spec.rb
@@ -73,9 +73,17 @@ describe ActiveJobStatus::JobBatch do
   end
 
   describe "::find" do
-    it "should return a JobBatch object" do
-      expect(ActiveJobStatus::JobBatch.find(batch_id: batch_id)).to \
-        be_an_instance_of ActiveJobStatus::JobBatch
+    describe "when a batch is present" do
+      it "should return a JobBatch object" do
+        expect(ActiveJobStatus::JobBatch.find(batch_id: batch_id)).to \
+          be_an_instance_of ActiveJobStatus::JobBatch
+      end
+    end
+
+    describe "when no batch is present" do
+      it "should return nil" do
+        expect(ActiveJobStatus::JobBatch.find(batch_id: "baz")).to be_nil
+      end
     end
   end
 
@@ -92,8 +100,8 @@ describe ActiveJobStatus::JobBatch do
                                     expire_in: 1)
       travel(2.seconds) do
         expect(
-          ActiveJobStatus::JobBatch.find(batch_id: "expiry").job_ids
-        ).to be_empty
+          ActiveJobStatus::JobBatch.find(batch_id: "expiry")
+        ).to be_nil
       end
     end
   end

--- a/spec/job_batch_spec.rb
+++ b/spec/job_batch_spec.rb
@@ -77,20 +77,6 @@ describe ActiveJobStatus::JobBatch do
       expect(ActiveJobStatus::JobBatch.find(batch_id: batch_id)).to \
         be_an_instance_of ActiveJobStatus::JobBatch
     end
-
-=begin
-    it "should return an array of jobs when a batch exists" do
-      expect(ActiveJobStatus::JobBatch.find(batch_id: batch_id)).to \
-        be_an_instance_of Array
-    end
-    it "should return the correct jobs" do
-      expect(ActiveJobStatus::JobBatch.find(batch_id: batch_id)).to \
-        match_array first_jobs
-    end
-    it "should return an empty array when no batch exists" do
-      expect(ActiveJobStatus::JobBatch.find(batch_id: "45")).to eq []
-    end
-=end
   end
 
   describe "expiring job" do


### PR DESCRIPTION
JobBatch::find now returns a JobBatch object, instead of an array of job ids. Fixes https://github.com/cdale77/active_job_status/issues/10