### PR TITLE
Set of small improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,8 +73,12 @@ be available for 72 hours after the job is queued. For right now you can't
 change that.
 
     my_job = MyJob.perform_later
-    ActiveJobStatus::JobStatus.get_status(job_id: my_job.job_id)
-    # => :queued, :working, :complete
+    job_status = ActiveJobStatus.fetch(my_job.job_id)
+    job_status.queued?
+    job_status.working?
+    job_status.completed?
+    job_status.status
+    # => :queued, :working, :completed, nil
 
 ### Job Batches
 For job batches you an use any key you want (for example, you might use a

--- a/README.md
+++ b/README.md
@@ -60,6 +60,12 @@ upgrading from versions < 1.0, you may need to update your code.*
     class MyJob < ActiveJobStatus::TrackableJob
     end
 
+Or you can just include ActiveJobStatus::Hooks into your job:
+
+    class MyJob < ActiveJob::Base
+      include ActiveJobStatus::Hooks
+    end
+
 ### Job Status
 
 Check the status of a job using the ActiveJob job_id. Status of a job will only

--- a/lib/active_job_status.rb
+++ b/lib/active_job_status.rb
@@ -1,3 +1,4 @@
+require "active_job_status/hooks"
 require "active_job_status/trackable_job"
 require "active_job_status/job_tracker"
 require "active_job_status/job_status"
@@ -10,4 +11,3 @@ module ActiveJobStatus
     attr_accessor :store
   end
 end
-

--- a/lib/active_job_status.rb
+++ b/lib/active_job_status.rb
@@ -9,5 +9,14 @@ require "active_job_status/configure_redis" if defined? Rails
 module ActiveJobStatus
   class << self
     attr_accessor :store
+
+    def get_status(job_id)
+      fetch(job_id).status
+    end
+
+    def fetch(job_id)
+      status = store.fetch(job_id)
+      JobStatus.new(status)
+    end
   end
 end

--- a/lib/active_job_status.rb
+++ b/lib/active_job_status.rb
@@ -8,7 +8,7 @@ require "active_job_status/configure_redis" if defined? Rails
 
 module ActiveJobStatus
   class << self
-    attr_accessor :store
+    attr_accessor :store, :expiration
 
     def get_status(job_id)
       fetch(job_id).status

--- a/lib/active_job_status/hooks.rb
+++ b/lib/active_job_status/hooks.rb
@@ -1,0 +1,13 @@
+module ActiveJobStatus
+  module Hooks
+    def self.included(base)
+      base.class_eval do
+        before_enqueue { ActiveJobStatus::JobTracker.enqueue(job_id: job_id) }
+
+        before_perform { ActiveJobStatus::JobTracker.update(job_id: job_id, status: :working) }
+
+        after_perform { ActiveJobStatus::JobTracker.remove(job_id: job_id) }
+      end
+    end
+  end
+end

--- a/lib/active_job_status/hooks.rb
+++ b/lib/active_job_status/hooks.rb
@@ -2,12 +2,18 @@ module ActiveJobStatus
   module Hooks
     def self.included(base)
       base.class_eval do
-        before_enqueue { ActiveJobStatus::JobTracker.enqueue(job_id: job_id) }
+        before_enqueue { job_tracker.enqueued }
 
-        before_perform { ActiveJobStatus::JobTracker.update(job_id: job_id, status: :working) }
+        before_perform { job_tracker.performing }
 
-        after_perform { ActiveJobStatus::JobTracker.remove(job_id: job_id) }
+        after_perform { job_tracker.completed }
       end
+    end
+
+    private
+
+    def job_tracker
+      @job_tracker ||= ActiveJobStatus::JobTracker.new(job_id: job_id)
     end
   end
 end

--- a/lib/active_job_status/job_batch.rb
+++ b/lib/active_job_status/job_batch.rb
@@ -36,7 +36,7 @@ module ActiveJobStatus
     def completed?
       job_statuses = []
       @job_ids.each do |job_id|
-        job_statuses << ActiveJobStatus::JobStatus.get_status(job_id: job_id)
+        job_statuses << ActiveJobStatus.get_status(job_id)
       end
       !job_statuses.any?
     end
@@ -62,4 +62,3 @@ module ActiveJobStatus
     end
   end
 end
-

--- a/lib/active_job_status/job_status.rb
+++ b/lib/active_job_status/job_status.rb
@@ -19,7 +19,11 @@ module ActiveJobStatus
     end
 
     def completed?
-      status == COMPLETED || status.nil?
+      status == COMPLETED
+    end
+
+    def empty?
+      status.nil?
     end
   end
 end

--- a/lib/active_job_status/job_status.rb
+++ b/lib/active_job_status/job_status.rb
@@ -1,12 +1,25 @@
 module ActiveJobStatus
-  module JobStatus
-    ENQUEUED = 'queued'.freeze
-    WORKING  = 'working'.freeze
+  class JobStatus
+    ENQUEUED  = :queued
+    WORKING   = :working
+    COMPLETED = :completed
 
-    # Provides a way to check on the status of a given job
-    def self.get_status(job_id:)
-      status = ActiveJobStatus.store.fetch(job_id)
-      status ? status.to_sym : nil
+    attr_reader :status
+
+    def initialize(status)
+      @status = status && status.to_sym
+    end
+
+    def queued?
+      status == ENQUEUED
+    end
+
+    def working?
+      status == WORKING
+    end
+
+    def completed?
+      status == COMPLETED || status.nil?
     end
   end
 end

--- a/lib/active_job_status/job_status.rb
+++ b/lib/active_job_status/job_status.rb
@@ -1,11 +1,12 @@
 module ActiveJobStatus
   module JobStatus
-    # Provides a way to check on the status of a given job
+    ENQUEUED = 'queued'.freeze
+    WORKING  = 'working'.freeze
 
+    # Provides a way to check on the status of a given job
     def self.get_status(job_id:)
       status = ActiveJobStatus.store.fetch(job_id)
       status ? status.to_sym : nil
     end
   end
 end
-

--- a/lib/active_job_status/job_tracker.rb
+++ b/lib/active_job_status/job_tracker.rb
@@ -1,17 +1,26 @@
 module ActiveJobStatus
-  module JobTracker
-    # Provides methods to CRUD job status records in Redis
+  class JobTracker
+    EXPIRATION = 72.hours.freeze
 
-    def self.enqueue(job_id:)
-      ActiveJobStatus.store.write(job_id, "queued", expires_in: 259200)
+    def initialize(job_id:, store: ActiveJobStatus.store)
+      @job_id = job_id
+      @store = store
     end
 
-    def self.update(job_id:, status:)
-      ActiveJobStatus.store.write(job_id, status.to_s)
+    def enqueued
+      store.write(job_id, JobStatus::ENQUEUED, expires_in: EXPIRATION)
     end
 
-    def self.remove(job_id:)
-      ActiveJobStatus.store.delete(job_id)
+    def performing
+      store.write(job_id, JobStatus::WORKING)
     end
+
+    def completed
+      store.delete(job_id)
+    end
+
+    private
+
+    attr_reader :job_id, :store
   end
 end

--- a/lib/active_job_status/job_tracker.rb
+++ b/lib/active_job_status/job_tracker.rb
@@ -8,11 +8,11 @@ module ActiveJobStatus
     end
 
     def enqueued
-      store.write(job_id, JobStatus::ENQUEUED, expires_in: EXPIRATION)
+      store.write(job_id, JobStatus::ENQUEUED.to_s, expires_in: EXPIRATION)
     end
 
     def performing
-      store.write(job_id, JobStatus::WORKING)
+      store.write(job_id, JobStatus::WORKING.to_s)
     end
 
     def completed

--- a/lib/active_job_status/job_tracker.rb
+++ b/lib/active_job_status/job_tracker.rb
@@ -1,18 +1,26 @@
 module ActiveJobStatus
   class JobTracker
-    EXPIRATION = 72.hours.freeze
+    DEFAULT_EXPIRATION = 72.hours.freeze
 
-    def initialize(job_id:, store: ActiveJobStatus.store)
+    def initialize(job_id:, store: ActiveJobStatus.store, expiration: ActiveJobStatus.expiration)
       @job_id = job_id
       @store = store
+      @expiration = expiration
     end
 
     def enqueued
-      store.write(job_id, JobStatus::ENQUEUED.to_s, expires_in: EXPIRATION)
+      store.write(
+        job_id,
+        JobStatus::ENQUEUED.to_s,
+        expires_in: expiration || DEFAULT_EXPIRATION
+      )
     end
 
     def performing
-      store.write(job_id, JobStatus::WORKING.to_s)
+      store.write(
+        job_id,
+        JobStatus::WORKING.to_s
+      )
     end
 
     def completed
@@ -21,6 +29,6 @@ module ActiveJobStatus
 
     private
 
-    attr_reader :job_id, :store
+    attr_reader :job_id, :store, :expiration
   end
 end

--- a/lib/active_job_status/job_tracker.rb
+++ b/lib/active_job_status/job_tracker.rb
@@ -24,6 +24,13 @@ module ActiveJobStatus
     end
 
     def completed
+      store.write(
+        job_id,
+        JobStatus::COMPLETED.to_s
+      )
+    end
+
+    def deleted
       store.delete(job_id)
     end
 

--- a/lib/active_job_status/trackable_job.rb
+++ b/lib/active_job_status/trackable_job.rb
@@ -1,11 +1,8 @@
 require "active_job"
+require "active_job_status/hooks"
+
 module ActiveJobStatus
   class TrackableJob < ActiveJob::Base
-
-    before_enqueue { ActiveJobStatus::JobTracker.enqueue(job_id: @job_id) }
-
-    before_perform { ActiveJobStatus::JobTracker.update(job_id: @job_id, status: :working) }
-
-    after_perform { ActiveJobStatus::JobTracker.remove(job_id: @job_id) }
+    include ActiveJobStatus::Hooks
   end
 end

--- a/spec/job_status_spec.rb
+++ b/spec/job_status_spec.rb
@@ -10,6 +10,7 @@ describe ActiveJobStatus::JobStatus do
       expect(job_status.queued?).to eq true
       expect(job_status.working?).to eq false
       expect(job_status.completed?).to eq false
+      expect(job_status.empty?).to eq false
       expect(job_status.status).to eq :queued
     end
   end
@@ -21,6 +22,7 @@ describe ActiveJobStatus::JobStatus do
       expect(job_status.queued?).to eq false
       expect(job_status.working?).to eq true
       expect(job_status.completed?).to eq false
+      expect(job_status.empty?).to eq false
       expect(job_status.status).to eq :working
     end
   end
@@ -32,6 +34,7 @@ describe ActiveJobStatus::JobStatus do
       expect(job_status.queued?).to eq false
       expect(job_status.working?).to eq false
       expect(job_status.completed?).to eq true
+      expect(job_status.empty?).to eq false
       expect(job_status.status).to eq :completed
     end
   end
@@ -42,7 +45,8 @@ describe ActiveJobStatus::JobStatus do
     it 'returns the correct state' do
       expect(job_status.queued?).to eq false
       expect(job_status.working?).to eq false
-      expect(job_status.completed?).to eq true
+      expect(job_status.completed?).to eq false
+      expect(job_status.empty?).to eq true
       expect(job_status.status).to eq nil
     end
   end

--- a/spec/job_status_spec.rb
+++ b/spec/job_status_spec.rb
@@ -1,26 +1,49 @@
 require "spec_helper"
 
 describe ActiveJobStatus::JobStatus do
+  let(:job_status) { described_class.new(status) }
 
-  describe "::get_status" do
+  context 'when queued' do
+    let(:status) { 'queued' }
 
-    describe "for a queued job" do
-      let(:job) { ActiveJobStatus::TrackableJob.new.enqueue }
-
-      it "should return :queued" do
-        expect(ActiveJobStatus::JobStatus.get_status(job_id: job.job_id)).to eq :queued
-      end
+    it 'returns the correct state' do
+      expect(job_status.queued?).to eq true
+      expect(job_status.working?).to eq false
+      expect(job_status.completed?).to eq false
+      expect(job_status.status).to eq :queued
     end
+  end
 
-    describe "for a complete job" do
+  context 'when working' do
+    let(:status) { 'working' }
 
-      let!(:job) { ActiveJobStatus::TrackableJob.perform_later }
-      sleep(10)
-      #clear_performed_jobs
-      it "should return :complete", pending: true do
-        expect(ActiveJobStatus::JobStatus.get_status(job_id: job.job_id)).to be_nil
-      end
+    it 'returns the correct state' do
+      expect(job_status.queued?).to eq false
+      expect(job_status.working?).to eq true
+      expect(job_status.completed?).to eq false
+      expect(job_status.status).to eq :working
+    end
+  end
+
+  context 'when completed' do
+    let(:status) { 'completed' }
+
+    it 'returns the correct state' do
+      expect(job_status.queued?).to eq false
+      expect(job_status.working?).to eq false
+      expect(job_status.completed?).to eq true
+      expect(job_status.status).to eq :completed
+    end
+  end
+
+  context 'when nil' do
+    let(:status) { nil }
+
+    it 'returns the correct state' do
+      expect(job_status.queued?).to eq false
+      expect(job_status.working?).to eq false
+      expect(job_status.completed?).to eq true
+      expect(job_status.status).to eq nil
     end
   end
 end
-

--- a/spec/job_tracker_spec.rb
+++ b/spec/job_tracker_spec.rb
@@ -10,6 +10,24 @@ describe ActiveJobStatus::JobTracker do
       tracker.enqueued
       expect(store.fetch(job_id)).to eq "queued"
     end
+
+    context 'with default expiration period' do
+      before { ActiveJobStatus.expiration = nil }
+
+      it 'expires in 72 hours' do
+        expect(store).to receive(:write).with(job_id, "queued", expires_in: 72.hours)
+        tracker.enqueued
+      end
+    end
+
+    context 'with default expiration period' do
+      before { ActiveJobStatus.expiration = 10.seconds }
+
+      it 'expires in the given period' do
+        expect(store).to receive(:write).with(job_id, "queued", expires_in: 10.seconds)
+        tracker.enqueued
+      end
+    end
   end
 
   describe "#performing" do

--- a/spec/job_tracker_spec.rb
+++ b/spec/job_tracker_spec.rb
@@ -38,8 +38,15 @@ describe ActiveJobStatus::JobTracker do
   end
 
   describe "#completed" do
-    it "removes the job from the store" do
+    it "updates the job status" do
       tracker.completed
+      expect(store.fetch(job_id)).to eq "completed"
+    end
+  end
+
+  describe "#deleted" do
+    it "removes the job from the store" do
+      tracker.deleted
       expect(store.fetch(job_id)).to eq nil
     end
   end

--- a/spec/job_tracker_spec.rb
+++ b/spec/job_tracker_spec.rb
@@ -1,29 +1,28 @@
 require "spec_helper"
 
 describe ActiveJobStatus::JobTracker do
-
   let!(:store) { ActiveJobStatus.store = new_store }
-  let(:job) { ActiveJobStatus::TrackableJob.new.enqueue }
+  let(:job_id) { 'j0b-1d' }
+  let(:tracker) { described_class.new(job_id: job_id) }
 
-  describe "::enqueue" do
-    it "should enqueue a job" do
-      ActiveJobStatus::JobTracker.enqueue(job_id: job.job_id)
-      expect(store.fetch(job.job_id)).to eq "queued"
+  describe "#enqueued" do
+    it "starts tracking the job" do
+      tracker.enqueued
+      expect(store.fetch(job_id)).to eq "queued"
     end
   end
 
-  describe "::update" do
-    it "should update a job status" do
-      ActiveJobStatus::JobTracker.update(job_id: job.job_id, status: :working)
-      expect(store.fetch(job.job_id)).to eq "working"
+  describe "#performing" do
+    it "updates the job status" do
+      tracker.performing
+      expect(store.fetch(job_id)).to eq "working"
     end
   end
 
-  describe "::remove" do
-    it "should remove the job from the cache store" do
-      ActiveJobStatus::JobTracker.remove(job_id: job.job_id)
-      expect(store.fetch(job.job_id)).to eq nil
+  describe "#completed" do
+    it "removes the job from the store" do
+      tracker.completed
+      expect(store.fetch(job_id)).to eq nil
     end
   end
 end
-

--- a/spec/trackable_job_spec.rb
+++ b/spec/trackable_job_spec.rb
@@ -13,22 +13,26 @@ describe ActiveJobStatus::TrackableJob do
     end
   end
 
-  describe 'hooks' do
+  describe 'tracking hooks' do
+    let(:job_tracker) { instance_double(ActiveJobStatus::JobTracker) }
+
     before do
       allow(job).to receive(:job_id) { 'j0b-1d' }
     end
 
     describe 'before enqueue' do
       it 'starts to track the job with JobTracker' do
-        expect(ActiveJobStatus::JobTracker).to receive(:enqueue).with(job_id: 'j0b-1d')
+        expect(ActiveJobStatus::JobTracker).to receive(:new).with(job_id: 'j0b-1d') { job_tracker }
+        expect(job_tracker).to receive(:enqueued)
         job.enqueue
       end
     end
 
     describe 'before/after perform' do
       it 'updates the job status with JobTracker and then remove it' do
-        expect(ActiveJobStatus::JobTracker).to receive(:update).with(job_id: 'j0b-1d', status: :working)
-        expect(ActiveJobStatus::JobTracker).to receive(:remove).with(job_id: 'j0b-1d')
+        expect(ActiveJobStatus::JobTracker).to receive(:new).with(job_id: 'j0b-1d') { job_tracker }
+        expect(job_tracker).to receive(:performing)
+        expect(job_tracker).to receive(:completed)
         job.perform_now
       end
     end

--- a/spec/trackable_job_spec.rb
+++ b/spec/trackable_job_spec.rb
@@ -1,21 +1,36 @@
 require "spec_helper"
 
 describe ActiveJobStatus::TrackableJob do
+  class DummyJob < ActiveJobStatus::TrackableJob
+    def perform; end;
+  end
 
-  describe "#initialize" do
+  let(:job) { DummyJob.new }
 
-    let(:trackable_job) { ActiveJobStatus::TrackableJob.new }
-
-    it "should create an object" do
-      expect(trackable_job).to be_an_instance_of ActiveJobStatus::TrackableJob
+  describe 'queueing' do
+    it "should have a job id" do
+      expect(job.job_id).to_not be_blank
     end
   end
 
-  describe 'queueing' do
-    let(:trackable_job) { ActiveJobStatus::TrackableJob.new.enqueue }
+  describe 'hooks' do
+    before do
+      allow(job).to receive(:job_id) { 'j0b-1d' }
+    end
 
-    it "should have a job id" do
-      expect(trackable_job.job_id).to_not be_blank
+    describe 'before enqueue' do
+      it 'starts to track the job with JobTracker' do
+        expect(ActiveJobStatus::JobTracker).to receive(:enqueue).with(job_id: 'j0b-1d')
+        job.enqueue
+      end
+    end
+
+    describe 'before/after perform' do
+      it 'updates the job status with JobTracker and then remove it' do
+        expect(ActiveJobStatus::JobTracker).to receive(:update).with(job_id: 'j0b-1d', status: :working)
+        expect(ActiveJobStatus::JobTracker).to receive(:remove).with(job_id: 'j0b-1d')
+        job.perform_now
+      end
     end
   end
 end


### PR DESCRIPTION
Hi. I'm using this gem on production, but before using it I did a set of small improvements that I think it's reasonable. They are split in several branches that I merged on my master, thus they depend on each other.
So they are easier reviewed separately and in a proper order. Here they are:

### [Move TrackableJob hooks out to a Hooks module](https://github.com/cdale77/active_job_status/commit/d6ac8a6f04778fcc94f6c0cc0ccddaa7f2a6d43d)

I've moved the hooks `before_enqueue`/`before_perform`/`after_perform` that provide the tracking feature out of the class and into a module. So that we can have the feature attached to the job by including the module, and not having to inherit from the `TrackableJob` class.

### [Refactor JobTracker](https://github.com/cdale77/active_job_status/commit/20c636656aae340d17ac3a5465d251fc7c569b29)

I've refactored the `JobTracker` class to replacing the class methods with instance methods, so that in the `Hooks` module we can make use of the `job_tracker` instance object.

### [Improved JobStatus](https://github.com/cdale77/active_job_status/commit/587b52af09b42fc6fc536bf2e8e709fcfffcdba0)

- Moved the methods that query for the job status (`get_status`, `fetch`) to the `ActiveJobStatus` class
- Made `ActiveJobStatus.fetch` return an instance of `JobStatus`
- Updated `JobStatus` so it can be initialized with a status string and be asked if it's `queued?`, `working?`, `completed?`.

### [Allow job status expiration to be configurable](https://github.com/cdale77/active_job_status/commit/0359cb30bb8309a9b0da38cfa16dde0584e2af72)

Added way to set the `ActiveJobStatus.expiration` to override the default expiration of 72 hours.

### [Write :complete state to symbolize completed jobs.](https://github.com/cdale77/active_job_status/commit/1ea18041f655d193df03b984f7796cfd7b3f219f)

Add a proper `completed` status instead of having `nil` statuses as being completed.