### PR TITLE
Add tracking for failed jobs and custom callbacks for each step in lifecycle

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ You can insert custom behavior for any point of the job life cycle.
 
 You could also create a parent class to handle behavior for all of your children classes.
 
-    class TrackableJob < ActiveJobJobStatus::TrackableJob
+    class TrackableJob < ActiveJobStatus::TrackableJob
 
       def on_perform_sucess(job)
         # send notification on slack, custom log message

--- a/README.md
+++ b/README.md
@@ -78,8 +78,56 @@ change that.
     job_status.queued?
     job_status.working?
     job_status.completed?
+    job_status.failed?
     job_status.status
-    # => :queued, :working, :completed, nil
+    # => :queued, :working, :completed, :failed, nil
+
+
+### Custom Callbacks
+
+You can insert custom behavior for any point of the job life cycle.
+
+    class MyJob < ActiveJobStatus::TrackableJob
+      # or include ActiveJobStatus::Hooks
+
+      def before_enqueue(job)
+        # code here
+      end
+
+      def on_enqueue_failure(exception, job)
+        # code here
+      end
+
+      def on_enqueue_success(job)
+        # code here
+      end
+
+      def before_perform(job)
+        # code here
+      end
+
+      def on_perform_failure(exception, job)
+        # code here
+      end
+
+      def on_perform_success(job)
+        # code here
+      end
+
+    end
+
+You could also create a parent class to handle behavior for all of your children classes.
+
+    class TrackableJob < ActiveJobJobStatus::TrackableJob
+
+      def on_perform_sucess(job)
+        # send notification on slack, custom log message
+      end
+
+    end
+
+    class MyJob < TrackableJob
+    end
 
 ### Job Batches
 For job batches you an use any key you want (for example, you might use a
@@ -107,6 +155,11 @@ You can easily add jobs to the batch:
 And you can ask the batch if all the jobs are completed or not:
 
     my_batch.completed?
+    # => true, false
+
+You can also ask if any of the jobs have failed in batch:
+
+    my_batch.failed?
     # => true, false
 
 You can ask the batch for other bits of information:

--- a/active_job_status.gemspec
+++ b/active_job_status.gemspec
@@ -22,6 +22,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "codeclimate-test-reporter", "~> 0.4"
+  spec.add_development_dependency "pry", '~> 0.10.4'
 
   spec.add_runtime_dependency "activejob", "> 4.2"
   spec.add_runtime_dependency "activesupport", "> 4.2"

--- a/active_job_status.gemspec
+++ b/active_job_status.gemspec
@@ -22,7 +22,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "codeclimate-test-reporter", "~> 0.4"
-  spec.add_development_dependency "pry", '~> 0.10.4'
 
   spec.add_runtime_dependency "activejob", "> 4.2"
   spec.add_runtime_dependency "activesupport", "> 4.2"

--- a/lib/active_job_status/hooks.rb
+++ b/lib/active_job_status/hooks.rb
@@ -9,10 +9,10 @@ module ActiveJobStatus
             job_tracker.enqueued
             block.call
             on_enqueue_success(job)
-          rescue Exception => exception
+          rescue StandardError => exception
             job_tracker.failed
             on_enqueue_failure(exception, job)
-            raise
+            raise exception
           end
         end
 
@@ -23,10 +23,10 @@ module ActiveJobStatus
             block.call
             job_tracker.completed
             on_perform_success(job)
-          rescue Exception => exception
+          rescue StandardError => exception
             job_tracker.failed
             on_perform_failure(exception, job)
-            raise
+            raise exception
           end
         end
 

--- a/lib/active_job_status/job_batch.rb
+++ b/lib/active_job_status/job_batch.rb
@@ -34,11 +34,15 @@ module ActiveJobStatus
     end
 
     def completed?
-      job_statuses = []
-      @job_ids.each do |job_id|
-        job_statuses << ActiveJobStatus.get_status(job_id)
+      @job_ids.all? do |job_id|
+        ActiveJobStatus.fetch(job_id).completed?
       end
-      !job_statuses.any?
+    end
+
+    def failed?
+      @job_ids.any? do |job_id|
+        ActiveJobStatus.fetch(job_id).failed?
+      end
     end
 
     def self.find(batch_id:)

--- a/lib/active_job_status/job_status.rb
+++ b/lib/active_job_status/job_status.rb
@@ -3,7 +3,7 @@ module ActiveJobStatus
     ENQUEUED  = :queued
     WORKING   = :working
     COMPLETED = :completed
-    FAILED = :failed
+    FAILED    = :failed
 
     attr_reader :status
 

--- a/lib/active_job_status/job_status.rb
+++ b/lib/active_job_status/job_status.rb
@@ -3,6 +3,7 @@ module ActiveJobStatus
     ENQUEUED  = :queued
     WORKING   = :working
     COMPLETED = :completed
+    FAILED = :failed
 
     attr_reader :status
 
@@ -20,6 +21,10 @@ module ActiveJobStatus
 
     def completed?
       status == COMPLETED
+    end
+
+    def failed?
+      status == FAILED
     end
 
     def empty?

--- a/lib/active_job_status/job_tracker.rb
+++ b/lib/active_job_status/job_tracker.rb
@@ -30,6 +30,13 @@ module ActiveJobStatus
       )
     end
 
+    def failed
+      store.write(
+        job_id,
+        JobStatus::FAILED.to_s
+      )
+    end
+
     def deleted
       store.delete(job_id)
     end

--- a/spec/job_batch_spec.rb
+++ b/spec/job_batch_spec.rb
@@ -57,8 +57,36 @@ describe ActiveJobStatus::JobBatch do
       update_store(id_array: total_jobs, job_status: :working)
       expect(batch.completed?).to be_falsey
     end
+    it "should be false when jobs are failed" do
+      update_store(id_array: total_jobs, job_status: :failed)
+      expect(batch.completed?).to be_falsey
+    end
     it "should be true when jobs are completed" do
-      clear_store(id_array: total_jobs)
+      update_store(id_array: total_jobs, job_status: :completed)
+      expect(batch.completed?).to be_truthy
+    end
+  end
+
+  describe "#failed?" do
+    it "should be false when jobs are queued" do
+      update_store(id_array: total_jobs, job_status: :queued)
+      expect(batch.completed?).to be_falsey
+    end
+    it "should be false when jobs are working" do
+      update_store(id_array: total_jobs, job_status: :working)
+      expect(batch.completed?).to be_falsey
+    end
+    it "should be true when jobs are failed" do
+      update_store(id_array: total_jobs, job_status: :failed)
+      expect(batch.completed?).to be_falsey
+    end
+    it "should be true when jobs are completed" do
+      update_store(id_array: total_jobs, job_status: :completed)
+      expect(batch.completed?).to be_truthy
+    end
+    it "should be true when one job has failed" do
+      update_store(id_array: total_jobs, job_status: :completed)
+      update_store(id_array: [total_jobs.last], job_status: :false)
       expect(batch.completed?).to be_truthy
     end
   end

--- a/spec/job_status_spec.rb
+++ b/spec/job_status_spec.rb
@@ -39,6 +39,19 @@ describe ActiveJobStatus::JobStatus do
     end
   end
 
+  context 'when failed' do
+    let(:status) { 'failed' }
+
+    it 'returns the correct state' do
+      expect(job_status.queued?).to eq false
+      expect(job_status.working?).to eq false
+      expect(job_status.completed?).to eq false
+      expect(job_status.failed?).to eq true
+      expect(job_status.empty?).to eq false
+      expect(job_status.status).to eq :failed
+    end
+  end
+
   context 'when nil' do
     let(:status) { nil }
 

--- a/spec/job_tracker_spec.rb
+++ b/spec/job_tracker_spec.rb
@@ -44,6 +44,13 @@ describe ActiveJobStatus::JobTracker do
     end
   end
 
+  describe "#failed" do
+    it "updates the job status" do
+      tracker.failed
+      expect(store.fetch(job_id)).to eq "failed"
+    end
+  end
+
   describe "#deleted" do
     it "removes the job from the store" do
       tracker.deleted


### PR DESCRIPTION
# Failed Jobs

You can now track jobs that have failed!
# Custom callback methods

I've defined custom methods that are overridable. Previously, writing code in `before_perform` block in child class would override active job status `before_perform` block. Custom methods can be used without ruining tracking functionality. You can also handle scenarios where job code fails.
