### PR TITLE
Add case of mixed job status for batch completed?

### DIFF
--- a/lib/active_job_status/job_batch.rb
+++ b/lib/active_job_status/job_batch.rb
@@ -34,9 +34,9 @@ module ActiveJobStatus
     end
 
     def completed?
-      @job_ids.map do |job_id|
+      !@job_ids.map do |job_id|
         job_status = ActiveJobStatus.get_status(job_id)
-        job_status == nil || job_status == :completed
+        job_status != nil && job_status != :completed
       end.any?
     end
 

--- a/spec/job_batch_spec.rb
+++ b/spec/job_batch_spec.rb
@@ -57,6 +57,11 @@ describe ActiveJobStatus::JobBatch do
       update_store(id_array: total_jobs, job_status: :working)
       expect(batch.completed?).to be_falsey
     end
+    it "should be false with mixed jobs status of working and completed" do
+      update_store_mixed_status(id_array: total_jobs, 
+                                job_status_array: [:working, :completed])
+      expect(batch.completed?).to be_falsey
+    end
     it "should be true when jobs are all completed" do
       update_store(id_array: total_jobs, job_status: :completed)
       expect(batch.completed?).to be_truthy
@@ -106,6 +111,13 @@ describe ActiveJobStatus::JobBatch do
   def update_store(id_array: [], job_status: :queued)
     id_array.each do |id|
       store.write(id, job_status.to_s)
+    end
+  end
+
+  def update_store_mixed_status(id_array: [], job_status_array: [:queued])
+    n_element = job_status_array.count
+    id_array.each_with_index do |id, index|
+      store.write(id, job_status_array[index % n_element].to_s)
     end
   end
 


### PR DESCRIPTION
v1.2 batch completed? doesn't seem to be working for mixed job statuses e.g. :working and :completed

`[12] pry(main)> batch.job_ids.map { |jid| ActiveJobStatus.fetch(jid).status }`
`=> [:working, :working, :completed, :completed]`
`[13] pry(main)> batch.job_ids.map do |job_id|`
`[13] pry(main)*   job_status = ActiveJobStatus.get_status(job_id)`
`[13] pry(main)*   job_status == nil || job_status == :completed`
`[13] pry(main)* end.any?`
`=> true` 
# 17
