### PR TITLE
Tweak JobBatch#completed? for improved readability

### DIFF
--- a/lib/active_job_status/job_batch.rb
+++ b/lib/active_job_status/job_batch.rb
@@ -34,10 +34,8 @@ module ActiveJobStatus
     end
 
     def completed?
-      !@job_ids.map do |job_id|
-        job_status = ActiveJobStatus.get_status(job_id)
-        job_status != nil && job_status != :completed
-      end.any?
+      # if all statuses are either nil or completed, the batch is done
+      job_statuses.all? { |job_status| job_status.empty? || job_status.completed? }
     end
 
     def self.find(batch_id:)
@@ -56,6 +54,11 @@ module ActiveJobStatus
 
     private
 
+    # returns ActiveJobStatus::JobStatus
+    # for each job_id
+    def job_statuses
+      @job_ids.map { |job_id| ActiveJobStatus.fetch(job_id) }
+    end
 
     def write(key, job_ids, expire_in=nil)
     end


### PR DESCRIPTION
Just a small change to the method definition for better readability. It now leans on the `JobStatus` methods a little more, which is also a pro as those are tested.

*Note: I didn't change any specs, as the current specs here should cover the change*