### PR TITLE
Raise error when store has not set

### DIFF
--- a/lib/active_job_status.rb
+++ b/lib/active_job_status.rb
@@ -23,7 +23,10 @@ module ActiveJobStatus
     end
 
     def store
-      @store or raise NoStoreError, "can't use ActiveJobStatus without store"
+      unless @store
+        raise NoStoreError, "can't use ActiveJobStatus without store"
+      end
+      @store
     end
   end
 end

--- a/lib/active_job_status.rb
+++ b/lib/active_job_status.rb
@@ -7,8 +7,11 @@ require "active_job_status/version"
 require "active_job_status/configure_redis" if defined? Rails
 
 module ActiveJobStatus
+  class NoStoreError < StandardError; end
+
   class << self
-    attr_accessor :store, :expiration
+    attr_accessor :expiration
+    attr_writer :store
 
     def get_status(job_id)
       fetch(job_id).status
@@ -17,6 +20,10 @@ module ActiveJobStatus
     def fetch(job_id)
       status = store.fetch(job_id)
       JobStatus.new(status)
+    end
+
+    def store
+      @store or raise NoStoreError, "can't use ActiveJobStatus without store"
     end
   end
 end

--- a/spec/active_job_status_spec.rb
+++ b/spec/active_job_status_spec.rb
@@ -1,0 +1,23 @@
+require 'spec_helper'
+
+describe ActiveJobStatus do
+  describe '.store' do
+    it 'raises error when store has not set' do
+      expect { ActiveJobStatus.store }.to raise_error(ActiveJobStatus::NoStoreError)
+    end
+
+    context 'when store has set' do
+      let(:store) { new_store }
+
+      before do
+        ActiveJobStatus.store = store
+      end
+
+      it 'returns configured store' do
+        expect { ActiveJobStatus.store }.to_not raise_error
+        expect(ActiveJobStatus.store).to eq store
+      end
+    end
+  end
+end
+

--- a/spec/active_job_status_spec.rb
+++ b/spec/active_job_status_spec.rb
@@ -20,4 +20,3 @@ describe ActiveJobStatus do
     end
   end
 end
-

--- a/spec/active_job_status_spec.rb
+++ b/spec/active_job_status_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require "spec_helper"
 
 describe ActiveJobStatus do
   describe '.store' do

--- a/spec/active_job_status_spec.rb
+++ b/spec/active_job_status_spec.rb
@@ -1,19 +1,19 @@
 require "spec_helper"
 
 describe ActiveJobStatus do
-  describe '.store' do
-    it 'raises error when store has not set' do
+  describe ".store" do
+    it "raises error when store has not set" do
       expect { ActiveJobStatus.store }.to raise_error(ActiveJobStatus::NoStoreError)
     end
 
-    context 'when store has set' do
+    context "when store has set" do
       let(:store) { new_store }
 
       before do
         ActiveJobStatus.store = store
       end
 
-      it 'returns configured store' do
+      it "returns configured store" do
         expect { ActiveJobStatus.store }.to_not raise_error
         expect(ActiveJobStatus.store).to eq store
       end


### PR DESCRIPTION
Recently I have been using active_job_status and this is very useful for me. Thanks!

I think it is helpful when raise error if store has not set.
So I add some codes and spec.

Also I think it needs specs about `.get_status` and `.fetch` on ActiveJobStatus module.
If this merged, I want to add these specs to `spec/active_job_status_spec.rb`.