### PR TITLE
lazily run `ActiveJobStatus.fetch` 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,11 +7,10 @@ services:
   - redis
 gemfile:
   - Gemfile
-  - gemfiles/redis-activesupport.gemfile
 notifications:
   email:
     recipients:
-    - cdale77@gmail.com
+    - vijay.krishna.ramesh@gmail.com
     on_failure: change
     on_success: never
 env:

--- a/active_job_status.gemspec
+++ b/active_job_status.gemspec
@@ -6,11 +6,11 @@ require 'active_job_status/version'
 Gem::Specification.new do |spec|
   spec.name          = "active_job_status"
   spec.version       = ActiveJobStatus::VERSION
-  spec.authors       = ["Brad Johnson"]
-  spec.email         = ["cdale77@gmail.com"]
+  spec.authors       = ["Brad Johnson", "Vijay Ramesh"]
+  spec.email         = ["cdale77@gmail.com", "vijay.krishna.ramesh@gmail.com"]
   spec.summary       = "Job status and batches for ActiveJob"
   spec.description   = "Job status and batches for ActiveJob. Create trackable jobs, check their status, and batch them together."
-  spec.homepage      = "https://github.com/cdale77/active_job_status"
+  spec.homepage      = "https://github.com/vijaykramesh/active_job_status"
   spec.license       = "MIT"
 
   spec.files         = `git ls-files -z`.split("\x0")
@@ -27,6 +27,6 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "activesupport", "> 4.2"
 
   spec.post_install_message = "If updating from a version below 1.0, please note " \
-                              "TrackabeJob is now namespaced inside of ActiveJob. " \
+                              "TrackableJob is now namespaced inside of ActiveJob. " \
                               "You will need update your code."
 end

--- a/gemfiles/redis-activesupport.gemfile
+++ b/gemfiles/redis-activesupport.gemfile
@@ -1,5 +1,0 @@
-source 'https://rubygems.org'
-
-gemspec path: "#{__dir__}/.."
-
-gem "redis-activesupport"

--- a/lib/active_job_status.rb
+++ b/lib/active_job_status.rb
@@ -1,3 +1,4 @@
+require "active_job_status/batch_hooks"
 require "active_job_status/hooks"
 require "active_job_status/trackable_job"
 require "active_job_status/job_tracker"

--- a/lib/active_job_status/batch_hooks.rb
+++ b/lib/active_job_status/batch_hooks.rb
@@ -1,0 +1,20 @@
+module ActiveJobStatus
+  module BatchHooks
+    def self.included(base)
+      base.class_eval do
+        before_enqueue { job_tracker.enqueued }
+
+        before_perform { job_tracker.performing }
+
+        after_perform { job_tracker.completed }
+      end
+    end
+
+    private
+
+    def job_tracker
+      batch_id = ActiveJobStatus.store.fetch(["batch_for", job_id].join(":"))
+      @job_tracker ||= ActiveJobStatus::JobTracker.new(job_id: job_id, batch_id: batch_id)
+    end
+  end
+end

--- a/lib/active_job_status/job_batch.rb
+++ b/lib/active_job_status/job_batch.rb
@@ -35,7 +35,10 @@ module ActiveJobStatus
 
     def completed?
       # if all statuses are either nil or completed, the batch is done
-      job_statuses.all? { |job_status| job_status.empty? || job_status.completed? }
+      @job_ids.all? { |job_id|
+        job_status = ActiveJobStatus.fetch(job_id)
+        job_status.empty? || job_status.completed?
+      }
     end
 
     def self.find(batch_id:)
@@ -54,11 +57,6 @@ module ActiveJobStatus
 
     private
 
-    # returns ActiveJobStatus::JobStatus
-    # for each job_id
-    def job_statuses
-      @job_ids.map { |job_id| ActiveJobStatus.fetch(job_id) }
-    end
 
     def write(key, job_ids, expire_in=nil)
     end

--- a/lib/active_job_status/job_batch.rb
+++ b/lib/active_job_status/job_batch.rb
@@ -7,6 +7,9 @@ module ActiveJobStatus
     def initialize(batch_id:, job_ids:, expire_in: 259200, store_data: true)
       @batch_id = batch_id
       @job_ids = job_ids
+
+      @remaining_jobs_key = ActiveJobStatus::JobTracker.remaining_jobs_key(batch_id)
+
       # the store_data flag is used by the ::find method return a JobBatch
       # object without re-saving the data
       self.store_data(expire_in: expire_in) if store_data
@@ -14,11 +17,19 @@ module ActiveJobStatus
 
     def store_data(expire_in:)
       ActiveJobStatus.store.delete(@batch_id) # delete any old batches
+      ActiveJobStatus.store.delete(@remaining_jobs_key)
+
       if ["ActiveSupport::Cache::RedisStore", "ActiveSupport::Cache::ReadthisStore"].include? ActiveJobStatus.store.class.to_s
         ActiveJobStatus.store.sadd(@batch_id, @job_ids)
         ActiveJobStatus.store.expire(@batch_id, expire_in)
       else
         ActiveJobStatus.store.write(@batch_id, @job_ids, expires_in: expire_in)
+      end
+
+      ActiveJobStatus.store.write(@remaining_jobs_key, @job_ids.size, raw: true, expires_in: expire_in)
+
+      @job_ids.each do |job_id|
+        ActiveJobStatus.store.write(["batch_for", job_id].join(":"), @batch_id, expires_in: expire_in)
       end
     end
 
@@ -31,14 +42,12 @@ module ActiveJobStatus
         existing_job_ids = ActiveJobStatus.store.fetch(@batch_id)
         ActiveJobStatus.store.write(@batch_id, existing_job_ids.to_a | job_ids)
       end
+
+      ActiveJobStatus.store.increment(@remaining_jobs_key, job_ids.size)
     end
 
     def completed?
-      # if all statuses are either nil or completed, the batch is done
-      @job_ids.all? { |job_id|
-        job_status = ActiveJobStatus.fetch(job_id)
-        job_status.empty? || job_status.completed?
-      }
+      ActiveJobStatus.store.read(@remaining_jobs_key, raw: true).to_i == 0
     end
 
     def self.find(batch_id:)

--- a/lib/active_job_status/job_tracker.rb
+++ b/lib/active_job_status/job_tracker.rb
@@ -2,8 +2,17 @@ module ActiveJobStatus
   class JobTracker
     DEFAULT_EXPIRATION = 72.hours.freeze
 
-    def initialize(job_id:, store: ActiveJobStatus.store, expiration: ActiveJobStatus.expiration)
+    def self.remaining_jobs_key(batch_id)
+      ["remaining_jobs", batch_id].join(":")
+    end
+
+    def self.batch_for_key(job_id)
+      ["batch_for", job_id].join(":")
+    end
+
+    def initialize(job_id:, batch_id: nil, store: ActiveJobStatus.store, expiration: ActiveJobStatus.expiration)
       @job_id = job_id
+      @batch_id = batch_id
       @store = store
       @expiration = expiration
     end
@@ -32,14 +41,32 @@ module ActiveJobStatus
         expires_in: expiration || DEFAULT_EXPIRATION
 
       )
+      maybe_remove_from_batch
     end
 
     def deleted
-      store.delete(job_id)
+      definitely_remove_from_batch
     end
 
     private
 
-    attr_reader :job_id, :store, :expiration
+    def maybe_remove_from_batch
+      previous_status = store.fetch(job_id)
+      if batch_id && previous_status && previous_status != JobStatus::COMPLETED.to_s
+        store.decrement(self.class.remaining_jobs_key(batch_id))
+        store.delete(self.class.batch_for_key(job_id))
+        true
+      else
+        false
+      end
+    end
+
+    # in the case of hard deleted jobs, we want to
+    # ensure we clean up the batch key for that job
+    def definitely_remove_from_batch
+      store.delete(self.class.batch_for_key(job_id)) unless maybe_remove_from_batch
+    end
+
+    attr_reader :job_id, :batch_id, :store, :expiration
   end
 end

--- a/lib/active_job_status/job_tracker.rb
+++ b/lib/active_job_status/job_tracker.rb
@@ -19,14 +19,18 @@ module ActiveJobStatus
     def performing
       store.write(
         job_id,
-        JobStatus::WORKING.to_s
+        JobStatus::WORKING.to_s,
+        expires_in: expiration || DEFAULT_EXPIRATION
+
       )
     end
 
     def completed
       store.write(
         job_id,
-        JobStatus::COMPLETED.to_s
+        JobStatus::COMPLETED.to_s,
+        expires_in: expiration || DEFAULT_EXPIRATION
+
       )
     end
 

--- a/lib/active_job_status/version.rb
+++ b/lib/active_job_status/version.rb
@@ -1,3 +1,3 @@
 module ActiveJobStatus
-  VERSION = "1.2.1"
+  VERSION = "1.2.2"
 end

--- a/spec/job_tracker_spec.rb
+++ b/spec/job_tracker_spec.rb
@@ -42,12 +42,58 @@ describe ActiveJobStatus::JobTracker do
       tracker.completed
       expect(store.fetch(job_id)).to eq "completed"
     end
+
+    context 'with a batch job' do
+      let(:batch_id) { '12345'}
+      let(:tracker) { described_class.new(job_id: job_id, batch_id: batch_id) }
+      it 'updates the batch tracking if the job was not already completed' do
+        allow(store).to receive(:fetch) { "working" }
+        expect(store).to receive(:decrement).with(ActiveJobStatus::JobTracker.remaining_jobs_key(batch_id))
+        expect(store).to receive(:delete).with(ActiveJobStatus::JobTracker.batch_for_key(job_id))
+        tracker.completed
+      end
+      it 'does not update the batch tracking if the job was already completed' do
+        allow(store).to receive(:fetch) { "completed" }
+        expect(store).not_to receive(:decrement)
+        expect(store).not_to receive(:delete)
+        tracker.completed
+      end
+      it 'does not update the batch tracking if the job does not exist' do
+        allow(store).to receive(:fetch) { nil }
+        expect(store).not_to receive(:decrement)
+        expect(store).not_to receive(:delete)
+        tracker.completed
+      end
+    end
   end
 
   describe "#deleted" do
     it "removes the job from the store" do
       tracker.deleted
       expect(store.fetch(job_id)).to eq nil
+    end
+
+    context 'with a batch job' do
+      let(:batch_id) { '12345'}
+      let(:tracker) { described_class.new(job_id: job_id, batch_id: batch_id) }
+      it 'updates the batch tracking if the job was not already completed' do
+        allow(store).to receive(:fetch) { "working" }
+        expect(store).to receive(:decrement).with(ActiveJobStatus::JobTracker.remaining_jobs_key(batch_id))
+        expect(store).to receive(:delete).with(ActiveJobStatus::JobTracker.batch_for_key(job_id))
+        tracker.deleted
+      end
+      it 'does not update the batch tracking if the job was already completed, but does delete the batch_for_key' do
+        allow(store).to receive(:fetch) { "completed" }
+        expect(store).not_to receive(:decrement)
+        expect(store).to receive(:delete).with(ActiveJobStatus::JobTracker.batch_for_key(job_id))
+        tracker.deleted
+      end
+      it 'does not update the batch tracking if the job does not exist, but does delete the batch_for_key' do
+        allow(store).to receive(:fetch) { nil }
+        expect(store).not_to receive(:decrement)
+        expect(store).to receive(:delete).with(ActiveJobStatus::JobTracker.batch_for_key(job_id))
+        tracker.deleted
+      end
     end
   end
 end


### PR DESCRIPTION
We noticed really bad performance when we have a batch with thousands of jobs and each of the child jobs has an `after_perform` that checks `ActiveJobStatus::JobBatch.find(batch_id: batch_id).completed?`.  This is because each job ends up doing thousands of GETs to redis.  Since `#all?` short circuits as soon as it hits a false value, doing the actual cache lookup inside the `#all?` block means we only read from redis until we hit a false value.

as an aside, this change means it is MUCH faster if you pass in the job ids in the reverse order that you will process them

```ruby
my_batch = ActiveJobStatus::JobBatch.new(batch_id: my_key,
                                         job_ids: my_jobs.reverse,
                                         expire_in: 500000)
```

as the final job will be the first checked when you call `#completed?` and the `#all?` will immediately short circuit.  

I don't think it is worth adding the `#reverse` inside this library itself, but maybe update the documentation to include this note? 